### PR TITLE
redirect after session.destroy

### DIFF
--- a/chapter6/chapter6.md
+++ b/chapter6/chapter6.md
@@ -517,8 +517,10 @@ The `logout` route is trivial. We clear the session by calling `destroy()` on `r
 
 ```js
 exports.logout = (req, res, next) => {
-  req.session.destroy()
-  res.redirect('/')
+  req.session.destroy((error) => {
+    if (error) return console.log(error)
+    res.redirect('/')
+  })
 }
 ```
 


### PR DESCRIPTION
`res.redirect` must be executed after `req.session.destroy`

in code below ...
```
exports.logout = (req, res, next) => {
  req.session.destroy((err) => {
    if (err) return console.log(err);
    console.log('in');
    res.redirect('/');
  });
  console.log('out');
}
```
output:
```
out
in
```